### PR TITLE
Fix scoring logic for open frames and full 10 frames

### DIFF
--- a/bowling_game.py
+++ b/bowling_game.py
@@ -26,7 +26,7 @@ class BowlingGame:
         score = 0
         frame_index = 0
 
-        for frame in range(9):
+        for frame in range(10):
             if self._is_strike(frame_index):
                 # Strike
                 score += 10 + self._strike_bonus(frame_index)
@@ -37,7 +37,7 @@ class BowlingGame:
                 frame_index += 2
             else:
                 # Open frame
-                score += self.rolls[frame_index]
+                score += self.rolls[frame_index] + self.rolls[frame_index + 1]
                 frame_index += 2
 
         return score


### PR DESCRIPTION
This fixes the scoring logic to account for all 10 frames, as well as handling open frames that were not being added correctly. This resolves the issue found in test_all_ones.